### PR TITLE
only show sidebar on homepage

### DIFF
--- a/WPTheme/socialistalternative/page.php
+++ b/WPTheme/socialistalternative/page.php
@@ -8,6 +8,10 @@
         }
     }
     echo '</main>';
-    get_sidebar();
+
+    if (is_page('Home') ) {
+        get_sidebar();
+      } 
+
     get_footer();
 ?>


### PR DESCRIPTION
I don't think it makes sense to have the sidebar on the other pages ('about', 'get involved' etc)